### PR TITLE
fix: normalize attribute keys to symbols

### DIFF
--- a/lib/telephone/service.rb
+++ b/lib/telephone/service.rb
@@ -20,6 +20,8 @@ module Telephone
     # Primary responsibility of initialize is to instantiate the
     # attributes of the service object with the expected values.
     def initialize(attributes = {})
+      attributes = attributes.transform_keys(&:to_sym)
+
       attributes.each do |key, value|
         send("#{key}=", value)
       end

--- a/spec/telephone_spec.rb
+++ b/spec/telephone_spec.rb
@@ -152,6 +152,19 @@ RSpec.describe Telephone::Service do
       expect(subject.new(foo: "baz").foo).to be "baz"
     end
 
+    it "accepts string keys" do
+      expect(subject.new("foo" => "baz").foo).to eq "baz"
+    end
+
+    it "handles string keys with callable defaults" do
+      service = Class.new(Telephone::Service) do
+        argument :name, default: "Default"
+        argument :message, default: -> { "Hello, #{name}!" }
+      end
+
+      expect(service.new("name" => "Custom").message).to eq "Hello, Custom!"
+    end
+
     context "if there is a required argument" do
       before { subject.public_send(:argument, :required_field, required: true) }
 


### PR DESCRIPTION
## Summary

Fixes a bug where passing attributes with string keys (e.g., from Rails params) would not properly override defaults.

## Problem

The `defaults` hash uses symbol keys, but `attributes.key?(key)` failed when `attributes` had string keys:

```ruby
# Before fix - broken with string keys
Service.new("name" => "John").computed  # callable saw default, not "John"
```

## Solution

Normalize attribute keys to symbols at the start of `initialize`:

```ruby
attributes = attributes.transform_keys(&:to_sym)
```

## Tests

Added specs for string key handling with both static and callable defaults.