### PR TITLE
feat!: redesign required option, add validates option

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,7 +1,7 @@
 fix: true
 parallel: true
 format: progress
-ruby_version: 2.6
+ruby_version: 3.4
 
 ignore:
   - "bin/**/*"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ end
 SimpleExample.call(name: "Benjamin").result #=> "Hello, Benjamin."
 ```
 
-Arguments can also be required, which will prevent the service object from executing unless they are present.
+Arguments can also be required, which will raise an `ArgumentError` if not provided:
 
 ```ruby
 class SimpleExample < ApplicationService
@@ -82,10 +82,8 @@ class SimpleExample < ApplicationService
   end
 end
 
-s = SimpleExample.call
-s.success? #=> false
-s.errors.full_messages #=> ["Name can't be blank"]
-s.result #=> nil
+SimpleExample.call #=> ArgumentError: missing required argument: name
+SimpleExample.call(name: nil) #=> works - nil is a valid value
 ```
 
 You can also give a default value for an argument.
@@ -110,6 +108,13 @@ end
 
 GreetingService.call.result #=> "Hello, John Doe!"
 GreetingService.call(first_name: "Jane").result #=> "Hello, Jane Doe!"
+```
+
+Arguments can also have inline validations using the `validates:` option:
+
+```ruby
+argument :email, validates: { format: { with: /@/ } }
+argument :name, required: true, validates: { length: { minimum: 2 } }
 ```
 
 ### Validations
@@ -155,3 +160,16 @@ yard server --reload
 The `--reload`, or `-r`, flag tells the server to auto reload the documentation on each request.
 
 Once the server is running, the documentation will by available at http://localhost:8808
+
+## Upgrading to 2.0
+
+Version 2.0 changes the behavior of `required: true`. Previously it added a presence validation; now it raises `ArgumentError` if the argument key isn't provided.
+
+To migrate, run:
+
+```bash
+rake telephone:migrate                    # defaults to app/services
+rake telephone:migrate[path/to/services]  # custom path
+```
+
+This adds `validates: { presence: true }` to preserve the old validation behavior.

--- a/lib/telephone.rb
+++ b/lib/telephone.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require "telephone/service"
+require "telephone/railtie" if defined?(Rails::Railtie)

--- a/lib/telephone/railtie.rb
+++ b/lib/telephone/railtie.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Telephone
   class Railtie < Rails::Railtie
     rake_tasks do

--- a/lib/telephone/railtie.rb
+++ b/lib/telephone/railtie.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Telephone
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      load "telephone/tasks/migrate.rake"
+    end
+  end
+end

--- a/lib/telephone/service.rb
+++ b/lib/telephone/service.rb
@@ -123,9 +123,6 @@ module Telephone
         @defaults ||= {}
       end
 
-      ##
-      # List of arguments marked as required. Uses a nil check instead of
-      # presence validation to avoid triggering queries on ActiveRecord relations.
       def required_arguments
         @required_arguments ||= []
       end

--- a/lib/telephone/tasks/migrate.rake
+++ b/lib/telephone/tasks/migrate.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+namespace :telephone do
+  desc "Migrate required: true to include validates: { presence: true } for v2.0 compatibility"
+  task :migrate, [:path] do |_t, args|
+    path = args[:path] || "app/services"
+
+    unless Dir.exist?(path)
+      puts "Directory not found: #{path}"
+      puts "Usage: rake telephone:migrate[path/to/services]"
+      exit 1
+    end
+
+    files_updated = 0
+
+    Dir.glob("#{path}/**/*.rb").each do |file|
+      content = File.read(file)
+      original = content.dup
+
+      # Match argument with required: true that doesn't already have validates:
+      content.gsub!(/^(\s*argument\s+:\w+.*)required:\s*true(.*)$/) do |line|
+        if line.include?("validates:")
+          line
+        else
+          indent = line[/^\s*/]
+          line.sub(/required:\s*true/, "required: true, validates: { presence: true }")
+        end
+      end
+
+      if content != original
+        File.write(file, content)
+        puts "Updated: #{file}"
+        files_updated += 1
+      end
+    end
+
+    if files_updated == 0
+      puts "No files needed updating."
+    else
+      puts "\nUpdated #{files_updated} file(s)."
+      puts "Review the changes and run your tests to verify."
+    end
+  end
+end

--- a/lib/telephone/tasks/migrate.rake
+++ b/lib/telephone/tasks/migrate.rake
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 namespace :telephone do
   desc "Migrate required: true to include validates: { presence: true } for v2.0 compatibility"
   task :migrate, [:path] do |_t, args|
@@ -17,12 +15,10 @@ namespace :telephone do
       content = File.read(file)
       original = content.dup
 
-      # Match argument with required: true that doesn't already have validates:
       content.gsub!(/^(\s*argument\s+:\w+.*)required:\s*true(.*)$/) do |line|
         if line.include?("validates:")
           line
         else
-          indent = line[/^\s*/]
           line.sub(/required:\s*true/, "required: true, validates: { presence: true }")
         end
       end

--- a/spec/migrate_task_spec.rb
+++ b/spec/migrate_task_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rake"
 require "fileutils"
 require "tmpdir"

--- a/spec/migrate_task_spec.rb
+++ b/spec/migrate_task_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "rake"
+require "fileutils"
+require "tmpdir"
+
+RSpec.describe "telephone:migrate rake task" do
+  let(:tmpdir) { Dir.mktmpdir }
+
+  after do
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  def run_migrate(path = tmpdir)
+    load File.expand_path("../lib/telephone/tasks/migrate.rake", __dir__)
+    Rake::Task["telephone:migrate"].reenable
+    Rake::Task["telephone:migrate"].invoke(path)
+  end
+
+  it "adds validates: { presence: true } to required: true arguments" do
+    File.write("#{tmpdir}/example_service.rb", <<~RUBY)
+      class ExampleService < Telephone::Service
+        argument :user, required: true
+        argument :name, default: "test"
+
+        def call
+          user
+        end
+      end
+    RUBY
+
+    run_migrate
+
+    content = File.read("#{tmpdir}/example_service.rb")
+    expect(content).to include("argument :user, required: true, validates: { presence: true }")
+    expect(content).to include('argument :name, default: "test"')
+  end
+
+  it "handles required: true with other options" do
+    File.write("#{tmpdir}/multi_option_service.rb", <<~RUBY)
+      class MultiOptionService < Telephone::Service
+        argument :email, required: true, default: nil
+      end
+    RUBY
+
+    run_migrate
+
+    content = File.read("#{tmpdir}/multi_option_service.rb")
+    expect(content).to include("required: true, validates: { presence: true }")
+  end
+
+  it "does not modify arguments that already have validates:" do
+    original = <<~RUBY
+      class AlreadyMigratedService < Telephone::Service
+        argument :email, required: true, validates: { format: { with: /@/ } }
+      end
+    RUBY
+
+    File.write("#{tmpdir}/already_migrated_service.rb", original)
+
+    run_migrate
+
+    content = File.read("#{tmpdir}/already_migrated_service.rb")
+    expect(content).to eq(original)
+  end
+
+  it "does not modify arguments without required: true" do
+    original = <<~RUBY
+      class NoRequiredService < Telephone::Service
+        argument :name, default: "test"
+        argument :optional
+      end
+    RUBY
+
+    File.write("#{tmpdir}/no_required_service.rb", original)
+
+    run_migrate
+
+    content = File.read("#{tmpdir}/no_required_service.rb")
+    expect(content).to eq(original)
+  end
+
+  it "handles multiple required arguments in the same file" do
+    File.write("#{tmpdir}/multiple_required_service.rb", <<~RUBY)
+      class MultipleRequiredService < Telephone::Service
+        argument :user, required: true
+        argument :account, required: true
+        argument :optional_thing
+      end
+    RUBY
+
+    run_migrate
+
+    content = File.read("#{tmpdir}/multiple_required_service.rb")
+    expect(content).to include("argument :user, required: true, validates: { presence: true }")
+    expect(content).to include("argument :account, required: true, validates: { presence: true }")
+    expect(content).to include("argument :optional_thing")
+    expect(content).not_to include("optional_thing, required")
+  end
+
+  it "preserves indentation" do
+    File.write("#{tmpdir}/indented_service.rb", <<~RUBY)
+      module Foo
+        class IndentedService < Telephone::Service
+          argument :user, required: true
+
+          def call
+            user
+          end
+        end
+      end
+    RUBY
+
+    run_migrate
+
+    content = File.read("#{tmpdir}/indented_service.rb")
+    expect(content).to include("    argument :user, required: true, validates: { presence: true }")
+  end
+end


### PR DESCRIPTION
## What changed

**`required: true` now raises an `ArgumentError` immediately if the argument isn't provided.**

Before this change, `required: true` added an ActiveModel presence validation. This was problematic because:

1. Presence validation calls `blank?` on the value, which triggers database queries on ActiveRecord relations
2. The error only surfaced after calling `valid?`, not at instantiation
3. It conflated "argument must be provided" with "value must not be blank"

Now, `required: true` simply checks if the key was included in the arguments hash. If not, it raises `ArgumentError` right away.

```ruby
# Raises ArgumentError: missing required argument: user
MyService.call

# These all work fine - the key is provided
MyService.call(user: some_user)
MyService.call(user: nil)    # nil is allowed
MyService.call(user: false)  # false is allowed
```

## New `validates:` option

If you want ActiveModel validations, there's now an explicit `validates:` option:

```ruby
argument :email, validates: { format: { with: /@/ } }
argument :name, required: true, validates: { length: { minimum: 2 } }
```

## Migration

A rake task is included to automatically update your services:

```bash
rake telephone:migrate                    # defaults to app/services
rake telephone:migrate[path/to/services]  # custom path
```

This adds `validates: { presence: true }` to any `argument` with `required: true`, preserving the old behavior.

### Manual migration

If you were relying on `required: true` to validate that values aren't blank:

```ruby
# Before
argument :user, required: true

# After - same validation behavior as before
argument :user, required: true, validates: { presence: true }
```

If you just wanted to ensure the argument was passed, no changes needed.